### PR TITLE
setup.py: ensuring Cython dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.pyc
 *.so
+triangle/core.c
 
+.eggs/
+build/
+triangle.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 os:
     - linux
-    - osx
 
 python:
     - "2.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
     - "3.4"
 
 before_install:
-    - pip install Cython
+    - pip install setuptools --upgrade
 
 install:
     - pip install .

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-from distutils.core import setup, Extension
-from Cython.Distutils import build_ext
+from setuptools import setup, Extension
 
 define_macros = [('VOID', 'int'),
                  ('REAL', 'double'),
@@ -30,8 +29,10 @@ setup(name='triangle',
         'Programming Language :: Python :: 3.4',
     ],
     url='http://dzhelil.info/triangle',
-    requires = ['numpy(>=1.7.0)', 'cython(>=0.18)'],
-    cmdclass = {'build_ext': build_ext},
+    setup_requires=['setuptools>=18.0',
+                    'Cython>=0.18'],
+    install_requires=['numpy>=1.7.0',
+                      'Cython>=0.18'],
     ext_modules=[
                  Extension('triangle.core', ['c/triangle.c', 
                                              'triangle/c_triangle.pxd', 


### PR DESCRIPTION
Now `Cython` is not prerequirement - it will be installed if needed.

New dependency: `setuptools>=18.0` (see [changelist](https://pythonhosted.org/setuptools/history.html))

This is fix for [issue#1](https://github.com/drufat/triangle/issues/1).