### PR TITLE
Updated *voronoi* in __init__.py:

### DIFF
--- a/triangle/__init__.py
+++ b/triangle/__init__.py
@@ -179,8 +179,8 @@ def voronoi(pts):
     n = np.array(_vorout.normlist).reshape((-1, 2))
     fltr = (e[:, 1] != -1)
     edges = e[fltr]
-    ray_origin = e[-fltr][:, 0]
-    ray_direct = n[-fltr]
+    ray_origin = e[~fltr][:, 0]
+    ray_direct = n[~fltr]
 
     return p, edges, ray_origin, ray_direct
 


### PR DESCRIPTION
Addressing the issue topic I started - #24 

```
    ray_origin = e[-fltr][:, 0]
    ray_direct = n[-fltr]
```
To
```
    ray_origin = e[~fltr][:, 0]
    ray_direct = n[~fltr]

```
I don't know if that will work in older versions of numpy though.