### PR TITLE
Make triangulating with option "n" (for neighborslist) work

### DIFF
--- a/triangle/tri.py
+++ b/triangle/tri.py
@@ -14,6 +14,8 @@ terms = (
     ('holelist', 'holes'),
 
     ('regionlist', 'regions'),
+
+    ('neighborlist', 'neighbors'),
 )
 
 translate_frw = {_0: _1 for _0, _1 in terms}


### PR DESCRIPTION
As a followup to #21, this makes the feature actually work with the refactored code.

Without this, we end up with a KeyError:
```
[..]
  File "...../xxx", line 31, in triangulate_tri
    'pn' # p .. constrained (triangulate a PSLG
  File "..../triangle/tri.py", line 65, in triangulate
    tri = {translate_frw[_]: tri[_] for _ in tri}
  File "..../triangle/tri.py", line 65, in <dictcomp>
    tri = {translate_frw[_]: tri[_] for _ in tri}
KeyError: 'neighborlist'
```