### PR TITLE
Do not use pkg_resources to determine version at runtime

### DIFF
--- a/triangle/__init__.py
+++ b/triangle/__init__.py
@@ -1,4 +1,4 @@
-__version__ = __import__('pkg_resources').get_distribution('triangle').version
+__version__ = '20190115.3'
 
 from triangle.data import (
     loads, load, get_data, show_data,


### PR DESCRIPTION
Significantly reduces import time

On this Windows workstation, the time for `import triangle` decreases from ~3.3 s to ~<0.2 s.

See also https://github.com/vispy/vispy/issues/1779, https://github.com/python-lz4/python-lz4/issues/154, and https://github.com/pypa/setuptools/issues/926