### PR TITLE
Build Wheels In Github Actions 

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,37 @@
+name: Build Wheels
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, windows-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - uses: actions/setup-python@v1
+      name: Install Python
+      with:
+        python-version: '3.7'
+
+    - name: Install cibuildwheel
+      run: |
+        python -m pip install cibuildwheel==1.3.0
+
+    - name: Install Visual C++ for Python 2.7
+      if: startsWith(matrix.os, 'windows')
+      run: |
+        choco install vcpython27 -f -y
+
+    - name: Build wheel
+      run: |
+        python -m cibuildwheel --output-dir wheelhouse
+
+    - uses: actions/upload-artifact@v1
+      with:
+        name: wheels
+        path: ./wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,34 +7,39 @@ jobs:
     name: Build wheel on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
+      # pypy (Python with a JIT) builds don't work due to numpy issue 
+      CIBW_SKIP: pp*
       CIBW_TEST_REQUIRES: pytest
       CIBW_TEST_COMMAND: "pytest {project}/tests"
     strategy:
       matrix:
         os: [ubuntu-18.04, windows-latest, macos-latest]
-
     steps:
     - uses: actions/checkout@v1
-
     - uses: actions/setup-python@v1
       name: Install Python
       with:
         python-version: '3.7'
-
     - name: Install cibuildwheel
       run: |
         python -m pip install cibuildwheel==1.3.0
-
     - name: Install Visual C++ for Python 2.7
       if: startsWith(matrix.os, 'windows')
       run: |
         choco install vcpython27 -f -y
-
     - name: Build wheel
       run: |
         python -m cibuildwheel --output-dir wheelhouse
-
     - uses: actions/upload-artifact@v1
       with:
         name: wheels
         path: ./wheelhouse
+    - name: Upload To PyPi
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      # TODO : remove `if false` statement after secrets are set in Github UI
+      if: false
+      run: |
+        pip install twine
+        twine upload ./wheelhouse/*

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,13 +3,12 @@ name: Build Wheels
 on: [push, pull_request]
 
 jobs:
-  env:
-    CIBW_TEST_REQUIRES: pytest
-    CIBW_TEST_COMMAND: "pytest --doctest-module triangle/tri.py"
-
   build_wheels:
     name: Build wheel on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      CIBW_TEST_REQUIRES: pytest
+      CIBW_TEST_COMMAND: "pytest --doctest-module triangle/tri.py"
     strategy:
       matrix:
         os: [ubuntu-18.04, windows-latest, macos-latest]

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CIBW_TEST_REQUIRES: pytest
-      CIBW_TEST_COMMAND: "pytest --doctest-module triangle/tri.py"
+      CIBW_TEST_COMMAND: "pytest --doctest-module {project}/triangle/tri.py"
     strategy:
       matrix:
         os: [ubuntu-18.04, windows-latest, macos-latest]

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,6 +3,10 @@ name: Build Wheels
 on: [push, pull_request]
 
 jobs:
+  env:
+    CIBW_TEST_REQUIRES: pytest
+    CIBW_TEST_COMMAND: "pytest --doctest-module triangle/tri.py"
+
   build_wheels:
     name: Build wheel on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CIBW_TEST_REQUIRES: pytest
-      CIBW_TEST_COMMAND: "pytest --doctest-module {project}/triangle/tri.py"
+      CIBW_TEST_COMMAND: "pytest {project}/tests"
     strategy:
       matrix:
         os: [ubuntu-18.04, windows-latest, macos-latest]

--- a/tests/test_triangle.py
+++ b/tests/test_triangle.py
@@ -1,0 +1,48 @@
+import numpy as np
+
+from triangle import (triangulate,
+                      convex_hull,
+                      voronoi,
+                      delaunay)
+
+
+def test_triangulate():
+
+    v = [[0, 0], [0, 1], [1, 1], [1, 0]]
+    t = triangulate({'vertices': v}, 'a0.2')
+    assert np.allclose(t['vertices'],
+                       [[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0], [0.5, 0.5], [0.0, 0.5], [0.5, 0.0], [1.0, 0.5], [0.5, 1.0]])
+    assert np.allclose(t['vertex_markers'],
+                       [[1], [1], [1], [1], [0], [1], [1], [1], [1]])
+    assert np.allclose(t['triangles'],
+                       [[7, 2, 4], [5, 0, 4], [4, 8, 1], [4, 1, 5], [4, 0, 6], [6, 3, 4], [4, 3, 7], [4, 2, 8]])
+
+
+def test_delaunay():
+    pts = [[0, 0], [0, 1], [0.5, 0.5], [1, 1], [1, 0]]
+    tri = delaunay(pts)
+    assert np.allclose(tri,
+                       [[1, 0, 2], [2, 4, 3], [4, 2, 0], [2, 3, 1]])
+
+
+def test_hull():
+
+    pts = [[0, 0], [0, 1], [1, 1], [1, 0]]
+    segments = convex_hull(pts)
+    assert np.allclose(segments,
+                       [[3, 0], [2, 3], [1, 2], [0, 1]])
+
+
+def test_voronoi():
+
+    pts = [[0, 0], [0, 1], [0.5, 0.5], [1, 1], [1, 0]]
+    points, edges, ray_origin, ray_direct = voronoi(pts)
+    assert np.allclose(points,
+                       [[0.0, 0.5], [1.0, 0.5], [0.5, 0.0], [0.5, 1.0]])
+    assert np.allclose(edges,
+                       [[0, 2], [0, 3], [1, 2], [1, 3]])
+
+    assert np.allclose(ray_origin,
+                       [0, 1, 2, 3])
+    assert np.allclose(ray_direct,
+                       [[-1.0, 0.0], [1.0, 0.0], [0.0, -1.0], [0.0, 1.0]])

--- a/tests/test_triangle.py
+++ b/tests/test_triangle.py
@@ -1,48 +1,63 @@
 import numpy as np
 
-from triangle import (triangulate,
-                      convex_hull,
-                      voronoi,
-                      delaunay)
+from triangle import triangulate, convex_hull, voronoi, delaunay
 
 
 def test_triangulate():
 
     v = [[0, 0], [0, 1], [1, 1], [1, 0]]
-    t = triangulate({'vertices': v}, 'a0.2')
-    assert np.allclose(t['vertices'],
-                       [[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0], [0.5, 0.5], [0.0, 0.5], [0.5, 0.0], [1.0, 0.5], [0.5, 1.0]])
-    assert np.allclose(t['vertex_markers'],
-                       [[1], [1], [1], [1], [0], [1], [1], [1], [1]])
-    assert np.allclose(t['triangles'],
-                       [[7, 2, 4], [5, 0, 4], [4, 8, 1], [4, 1, 5], [4, 0, 6], [6, 3, 4], [4, 3, 7], [4, 2, 8]])
+    t = triangulate({"vertices": v}, "a0.2")
+    assert np.allclose(
+        t["vertices"],
+        [
+            [0.0, 0.0],
+            [0.0, 1.0],
+            [1.0, 1.0],
+            [1.0, 0.0],
+            [0.5, 0.5],
+            [0.0, 0.5],
+            [0.5, 0.0],
+            [1.0, 0.5],
+            [0.5, 1.0],
+        ],
+    )
+    assert np.allclose(
+        t["vertex_markers"], [[1], [1], [1], [1], [0], [1], [1], [1], [1]]
+    )
+    assert np.allclose(
+        t["triangles"],
+        [
+            [7, 2, 4],
+            [5, 0, 4],
+            [4, 8, 1],
+            [4, 1, 5],
+            [4, 0, 6],
+            [6, 3, 4],
+            [4, 3, 7],
+            [4, 2, 8],
+        ],
+    )
 
 
 def test_delaunay():
     pts = [[0, 0], [0, 1], [0.5, 0.5], [1, 1], [1, 0]]
     tri = delaunay(pts)
-    assert np.allclose(tri,
-                       [[1, 0, 2], [2, 4, 3], [4, 2, 0], [2, 3, 1]])
+    assert np.allclose(tri, [[1, 0, 2], [2, 4, 3], [4, 2, 0], [2, 3, 1]])
 
 
 def test_hull():
 
     pts = [[0, 0], [0, 1], [1, 1], [1, 0]]
     segments = convex_hull(pts)
-    assert np.allclose(segments,
-                       [[3, 0], [2, 3], [1, 2], [0, 1]])
+    assert np.allclose(segments, [[3, 0], [2, 3], [1, 2], [0, 1]])
 
 
 def test_voronoi():
 
     pts = [[0, 0], [0, 1], [0.5, 0.5], [1, 1], [1, 0]]
     points, edges, ray_origin, ray_direct = voronoi(pts)
-    assert np.allclose(points,
-                       [[0.0, 0.5], [1.0, 0.5], [0.5, 0.0], [0.5, 1.0]])
-    assert np.allclose(edges,
-                       [[0, 2], [0, 3], [1, 2], [1, 3]])
+    assert np.allclose(points, [[0.0, 0.5], [1.0, 0.5], [0.5, 0.0], [0.5, 1.0]])
+    assert np.allclose(edges, [[0, 2], [0, 3], [1, 2], [1, 3]])
 
-    assert np.allclose(ray_origin,
-                       [0, 1, 2, 3])
-    assert np.allclose(ray_direct,
-                       [[-1.0, 0.0], [1.0, 0.0], [0.0, -1.0], [0.0, 1.0]])
+    assert np.allclose(ray_origin, [0, 1, 2, 3])
+    assert np.allclose(ray_direct, [[-1.0, 0.0], [1.0, 0.0], [0.0, -1.0], [0.0, 1.0]])

--- a/triangle/__init__.py
+++ b/triangle/__init__.py
@@ -1,13 +1,13 @@
-from triangle.version import (
+from .version import (
     __version__,
 )
-from triangle.data import (
+from .data import (
     loads, load, get_data, show_data,
 )
-from triangle.plot import (
+from .plot import (
     plot, comparev, compare,
 )
-from triangle.tri import (
+from .tri import (
     triangulate,
     convex_hull, delaunay, voronoi,
 )

--- a/triangle/tri.py
+++ b/triangle/tri.py
@@ -1,4 +1,4 @@
-from triangle.core import triang
+from .core import triang
 
 terms = (
     ('pointlist', 'vertices'),


### PR DESCRIPTION
Hey, thanks for all the great work on the `triangle` binding! I love the minimal nature and reliability, which is probably why a bunch of upstream packages have started depending on `triangle` too. To hopefully help, this PR uses [cibuildwheel](https://github.com/joerick/cibuildwheel) and Github Actions to build compiled wheels for Windows, Linux, and MacOS for a bunch flavors of Python: 
```
triangle-20200404-cp27-cp27m-macosx_10_9_x86_64.whl
triangle-20200404-cp27-cp27m-manylinux1_i686.whl
triangle-20200404-cp27-cp27m-manylinux1_x86_64.whl
triangle-20200404-cp27-cp27m-manylinux2010_i686.whl
triangle-20200404-cp27-cp27m-manylinux2010_x86_64.whl
triangle-20200404-cp27-cp27m-win32.whl
triangle-20200404-cp27-cp27m-win_amd64.whl
triangle-20200404-cp27-cp27mu-manylinux1_i686.whl
triangle-20200404-cp27-cp27mu-manylinux1_x86_64.whl
triangle-20200404-cp27-cp27mu-manylinux2010_i686.whl
triangle-20200404-cp27-cp27mu-manylinux2010_x86_64.whl
triangle-20200404-cp35-cp35m-macosx_10_9_x86_64.whl
triangle-20200404-cp35-cp35m-manylinux1_i686.whl
triangle-20200404-cp35-cp35m-manylinux1_x86_64.whl
triangle-20200404-cp35-cp35m-manylinux2010_i686.whl
triangle-20200404-cp35-cp35m-manylinux2010_x86_64.whl
triangle-20200404-cp35-cp35m-win32.whl
triangle-20200404-cp35-cp35m-win_amd64.whl
triangle-20200404-cp36-cp36m-macosx_10_9_x86_64.whl
triangle-20200404-cp36-cp36m-manylinux1_i686.whl
triangle-20200404-cp36-cp36m-manylinux1_x86_64.whl
triangle-20200404-cp36-cp36m-manylinux2010_i686.whl
triangle-20200404-cp36-cp36m-manylinux2010_x86_64.whl
triangle-20200404-cp36-cp36m-win32.whl
triangle-20200404-cp36-cp36m-win_amd64.whl
triangle-20200404-cp37-cp37m-macosx_10_9_x86_64.whl
triangle-20200404-cp37-cp37m-manylinux1_i686.whl
triangle-20200404-cp37-cp37m-manylinux1_x86_64.whl
triangle-20200404-cp37-cp37m-manylinux2010_i686.whl
triangle-20200404-cp37-cp37m-manylinux2010_x86_64.whl
triangle-20200404-cp37-cp37m-win32.whl
triangle-20200404-cp37-cp37m-win_amd64.whl
triangle-20200404-cp38-cp38-macosx_10_9_x86_64.whl
triangle-20200404-cp38-cp38-manylinux1_i686.whl
triangle-20200404-cp38-cp38-manylinux1_x86_64.whl
triangle-20200404-cp38-cp38-manylinux2010_i686.whl
triangle-20200404-cp38-cp38-manylinux2010_x86_64.whl
triangle-20200404-cp38-cp38-win32.whl
triangle-20200404-cp38-cp38-win_amd64.whl
```


A few thoughts:
- Should: fix #50 fix #39
- It is building and testing all of these successfully, [here's a build](https://github.com/mikedh/triangle/actions/runs/87019543), and you can download the `wheels` artifact here as well. 
- If you want to release wheels to PyPi, you should just have to set `PYPI_USERNAME` and `PYPI_PASSWORD` using the Github secrets interface, and remove the `if: false` from the `wheels.yml` file. 
- I've never successfully compiled Python packages on Windows either, so if there isn't a wheel I usually bail on that package.
- Github actions is integrated with Github (you don't have to do anything to get it building), has a nice syntax, and at least for `trimesh`, executes jobs almost 3x faster than Travis. I recently replaced a mix of Travis, CircleCI, and Appveyor entirely with GitHub Actions and have been super happy with it.  
- `cibuildwheel` has a really impressive build matrix and abstracts a lot of complexity really nicely (IMHO).  
- I broke out doctests into separate `tests/test_triangle.py` file. This lets pytest use the installed `triangle`, I was running in to issues with the pure doctests approach in CI. CIBW runs the unit tests using the built wheel across the entire build matrix, which is nice. 
- I changed the import style from `from triangle.core` to `from .core`