### PR TITLE
Fix github action for publishing wheels to pypi

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,6 +1,6 @@
 name: Build Wheels
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build_wheels:
@@ -15,14 +15,10 @@ jobs:
         submodules: 'recursive'
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.10'
     - name: Install cibuildwheel
       run: |
         python -m pip install cibuildwheel
-    - name: Install Visual C++ for Python 2.7
-      if: startsWith(matrix.os, 'windows')
-      run: |
-        choco install vcpython27 -f -y
     - name: Build wheel
       run: |
         python -m cibuildwheel --output-dir dist


### PR DESCRIPTION
Hi @drufat, thanks for this great library! 

I'm interested in using `triangle` for Python 3.9 and 3.10, but it seems that wheels are not available. It looks like easiest way to build `triangle` is via the github actions introduced by #51 (which works well on my fork).

This PR fixes the github action to build the wheels:

- Removed installation of vcpython27, because it has been deprecated
- Added 'workflow_dispatch' as a trigger, so that the action can be started from the 'actions' tab.

It would be useful to also have the wheels available on pypi. If this PR gets merged, then it should automatically update the wheels on pypi.

Closes #57