### PR TITLE
add cibuildwheel configs for mac-arm64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,7 @@ skip = ['pp*', '*musllinux*']
 test-skip = ['*-manylinux_i686']
 test-requires = 'pytest'
 test-command = 'pytest {project}/tests'
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]
+test-skip = ["*arm64"]


### PR DESCRIPTION
This PR adds configurations to build wheels for mac-arm64. [Workflow](https://github.com/j042/triangle/actions/runs/7114500878/job/19368670418) ran without any issue.
Fixes #64.